### PR TITLE
Fix non-strict sequence truncation bug in VAE utilities

### DIFF
--- a/vae_module/exceptions.py
+++ b/vae_module/exceptions.py
@@ -12,3 +12,13 @@ class SequenceLengthError(VAEError):
 
 class DeviceNotAvailableError(VAEError):
     """Raised when the requested device is not available."""
+
+
+class CheckpointLoadError(VAEError):
+    """Raised when a checkpoint file cannot be loaded."""
+
+    def __init__(self, path: str, original: Exception):
+        msg = f"Failed to load checkpoint '{path}': {original}"
+        super().__init__(msg)
+        self.path = path
+        self.original = original

--- a/vae_module/tests/test_loader.py
+++ b/vae_module/tests/test_loader.py
@@ -1,0 +1,54 @@
+import pathlib
+import sys
+
+import pickle
+import pytest
+import torch
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from vae_module.config import Config
+from vae_module.exceptions import CheckpointLoadError
+from vae_module.loader import _load_checkpoint, load_vae
+
+
+def test__load_checkpoint_retries_with_weights_only(monkeypatch):
+    device = torch.device("cpu")
+    calls = []
+
+    def fake_load(path, *args, **kwargs):
+        calls.append(kwargs)
+        if kwargs.get("weights_only") is False:
+            return {"ok": True}
+        raise pickle.UnpicklingError("weights-only mode incompatible")
+
+    monkeypatch.setattr(torch, "load", fake_load)
+
+    checkpoint = _load_checkpoint("dummy.pt", device)
+
+    assert checkpoint == {"ok": True}
+    assert calls == [
+        {"map_location": device},
+        {"map_location": device, "weights_only": False},
+    ]
+
+
+def test__load_checkpoint_invalid_file(tmp_path):
+    device = torch.device("cpu")
+    bad_path = tmp_path / "bad.pt"
+    bad_path.write_bytes(b"\r\n")
+
+    with pytest.raises(CheckpointLoadError):
+        _load_checkpoint(str(bad_path), device)
+
+
+def test_load_vae_raises_for_invalid_checkpoint():
+    cfg = Config(model_path=str(ROOT / "models" / "ep002.pt"), device="cpu")
+    vocab_size = 32
+    pad_idx = 0
+    bos_idx = 1
+
+    with pytest.raises(CheckpointLoadError):
+        load_vae(cfg, vocab_size, pad_idx, bos_idx)

--- a/vae_module/tests/test_utils.py
+++ b/vae_module/tests/test_utils.py
@@ -1,0 +1,41 @@
+import pathlib
+import sys
+
+import pytest
+import torch
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from vae_module.classes import Tokenizer
+from vae_module.exceptions import InvalidSequenceError, SequenceLengthError
+from vae_module.utils import sequence_to_tensor
+
+
+def make_tokenizer():
+    return Tokenizer(["<cls>", "<pad>", "A", "B", "C"])
+
+
+def test_sequence_to_tensor_raises_on_unknown_token():
+    tokenizer = make_tokenizer()
+    with pytest.raises(InvalidSequenceError):
+        sequence_to_tensor("AD", tokenizer, max_len=2)
+
+
+def test_sequence_to_tensor_strict_length_check():
+    tokenizer = make_tokenizer()
+    with pytest.raises(SequenceLengthError):
+        sequence_to_tensor("ABC", tokenizer, max_len=2)
+
+
+def test_sequence_to_tensor_truncates_when_not_strict():
+    tokenizer = make_tokenizer()
+    tensor = sequence_to_tensor("ABC", tokenizer, max_len=2, strict=False)
+    assert torch.equal(
+        tensor,
+        torch.tensor([
+            tokenizer.get_idx("A"),
+            tokenizer.get_idx("B"),
+        ]),
+    )

--- a/vae_module/utils.py
+++ b/vae_module/utils.py
@@ -13,7 +13,7 @@ def sequence_to_tensor(seq: str, tokenizer: "Tokenizer", max_len: int,strict=Tru
         if len(seq) > max_len:
             raise SequenceLengthError(len(seq), max_len)
     else:
-        seq[:max_len]
+        seq = seq[:max_len]
     ids = [tokenizer.get_idx(c) for c in seq]
     return torch.tensor(ids, dtype=torch.long)
 


### PR DESCRIPTION
## Summary
- ensure `sequence_to_tensor` properly truncates sequences when `strict=False`
- add regression tests covering invalid tokens, strict length checks, and non-strict truncation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce72e4589c832b87eebf46f55fa572