### PR TITLE
Improve checkpoint load error guidance

### DIFF
--- a/vae_module/tests/test_loader.py
+++ b/vae_module/tests/test_loader.py
@@ -53,8 +53,10 @@ def test__load_checkpoint_invalid_file(tmp_path):
     bad_path = tmp_path / "bad.pt"
     bad_path.write_bytes(b"\r\n")
 
-    with pytest.raises(CheckpointLoadError):
+    with pytest.raises(CheckpointLoadError) as excinfo:
         _load_checkpoint(str(bad_path), device)
+
+    assert "git lfs pull" in str(excinfo.value).lower()
 
 
 def test_load_vae_raises_for_invalid_checkpoint():


### PR DESCRIPTION
## Summary
- add troubleshooting hints when checkpoint files look truncated or like Git LFS pointers
- ensure the loader test asserts the improved error guidance is surfaced

## Testing
- pytest vae_module/tests/test_loader.py

------
https://chatgpt.com/codex/tasks/task_e_68ce8133063c832b9a79e209dc3f5841